### PR TITLE
Added custom fields handler factory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   },
   "require": {
     "roave/security-advisories": "dev-master",
-    "wpml/page-builders": "dev-master"
+    "wpml/page-builders": "dev-wpmlpb-149"
   },
   "require-dev": {
     "phpunit/phpunit": "~5.7",

--- a/src/class-wpml-beaver-builder-handle-custom-fields-factory.php
+++ b/src/class-wpml-beaver-builder-handle-custom-fields-factory.php
@@ -1,0 +1,8 @@
+<?php
+
+class WPML_PB_Beaver_Builder_Handle_Custom_Fields_Factory implements IWPML_Backend_Action_Loader, IWPML_AJAX_Action_Loader, IWPML_Frontend_Action_Loader {
+
+	public function create() {
+		return new WPML_PB_Handle_Custom_Fields( new WPML_Beaver_Builder_Data_Settings() );
+	}
+}

--- a/src/class-wpml-beaver-builder-integration-factory.php
+++ b/src/class-wpml-beaver-builder-integration-factory.php
@@ -3,6 +3,13 @@
 class WPML_Beaver_Builder_Integration_Factory {
 
 	public function create() {
+		$action_filter_loader = new WPML_Action_Filter_Loader();
+		$action_filter_loader->load(
+			array(
+				'WPML_PB_Beaver_Builder_Handle_Custom_Fields_Factory',
+			)
+		);
+
 		$nodes = new WPML_Beaver_Builder_Translatable_Nodes();
 		$data_settings = new WPML_Beaver_Builder_Data_Settings();
 

--- a/tests/phpunit/tests/test-wpml-pb-beaver-builder-handle-custom-fields-factory.php
+++ b/tests/phpunit/tests/test-wpml-pb-beaver-builder-handle-custom-fields-factory.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * Class Test_WPML_PB_Beaver_Builder_Handle_Custom_Fields_Factory
+ *
+ * @group wpmlpb-149
+ */
+class Test_WPML_PB_Beaver_Builder_Handle_Custom_Fields_Factory extends OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function it_runs_on_back_front_ajax() {
+		$subject = new WPML_PB_Beaver_Builder_Handle_Custom_Fields_Factory();
+		$this->assertInstanceOf( 'IWPML_Backend_Action_Loader', $subject );
+		$this->assertInstanceOf( 'IWPML_AJAX_Action_Loader', $subject );
+		$this->assertInstanceOf( 'IWPML_Frontend_Action_Loader', $subject );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_returns_instance_of_custom_fields_handler() {
+		$subject = new WPML_PB_Beaver_Builder_Handle_Custom_Fields_Factory();
+		$this->assertInstanceOf( 'WPML_PB_Handle_Custom_Fields', $subject->create() );
+	}
+}
+
+if ( ! interface_exists( 'IWPML_Backend_Action_Loader' ) ) {
+	interface IWPML_Backend_Action_Loader{}
+}
+
+if ( ! interface_exists( 'IWPML_AJAX_Action_Loader' ) ) {
+	interface IWPML_AJAX_Action_Loader{}
+}
+
+if ( ! interface_exists( 'IWPML_Frontend_Action_Loader' ) ) {
+	interface IWPML_Frontend_Action_Loader{}
+}


### PR DESCRIPTION
This class will be responsible by copying custom fields when a page without any string package is sent to translation. Also, to avoid sending the post body for translation, copying it instead.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlpb-146
