### PR TITLE
Reduce cross-dependency between page builder packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,11 @@
     ]
   },
   "require": {
-    "roave/security-advisories": "dev-master",
-    "wpml/page-builders": "dev-master"
+    "roave/security-advisories": "dev-master"
   },
   "require-dev": {
     "phpunit/phpunit": "~5.7",
-    "otgs/unit-tests-framework": "~1.2.0"
+    "otgs/unit-tests-framework": "~1.2.0",
+    "wpml/page-builders": "dev-master"
   }
 }


### PR DESCRIPTION
Moved `wpml/page-builders` to dev dependencies.

Note that this does not have any incidence on the `composer.lock` file.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlpb-155