### PR TITLE
Delete the layout string

### DIFF
--- a/src/class-wpml-beaver-builder-cleanup-hooks-factory.php
+++ b/src/class-wpml-beaver-builder-cleanup-hooks-factory.php
@@ -1,0 +1,8 @@
+<?php
+
+class WPML_Beaver_Builder_Cleanup_Hooks_Factory implements IWPML_Backend_Action_Loader, IWPML_Frontend_Action_Loader {
+
+	public function create() {
+		return new WPML_Beaver_Builder_Cleanup_Hooks();
+	}
+}

--- a/src/class-wpml-beaver-builder-cleanup-hooks.php
+++ b/src/class-wpml-beaver-builder-cleanup-hooks.php
@@ -1,0 +1,35 @@
+<?php
+
+class WPML_Beaver_Builder_Cleanup_Hooks implements IWPML_Action {
+
+	public function add_hooks() {
+		add_action( 'wpml_delete_unused_package_strings', array( $this, 'delete_block_layout_string' ) );
+	}
+
+	/**
+	 * @param array $package_data
+	 */
+	public function delete_block_layout_string( $package_data ) {
+		$packages = apply_filters( 'wpml_st_get_post_string_packages', array(), $package_data['post_id'] );
+
+		/** @var WPML_Package[] $packages */
+		foreach ( $packages as $package ) {
+			if ( WPML_Gutenberg_Integration::PACKAGE_ID === $package->kind ) {
+				$strings = $package->get_package_strings();
+
+				$is_unique_string = count( $strings ) < 2;
+
+				foreach ( $strings as $string ) {
+					if ( 'fl-builder/layout' === $string->title ) {
+
+						if ( $is_unique_string ) {
+							do_action( 'wpml_delete_package', $package->name, $package->kind );
+						} else {
+							do_action( 'wpml_st_delete_all_string_data', $string->id );
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/src/class-wpml-beaver-builder-integration-factory.php
+++ b/src/class-wpml-beaver-builder-integration-factory.php
@@ -10,6 +10,7 @@ class WPML_Beaver_Builder_Integration_Factory {
 			array(
 				'WPML_PB_Beaver_Builder_Handle_Custom_Fields_Factory',
 				'WPML_Beaver_Builder_Media_Hooks_Factory',
+				'WPML_Beaver_Builder_Cleanup_Hooks_Factory',
 			)
 		);
 

--- a/tests/phpunit/tests/media/test-wpml-beaver-builder-update-media-factory.php
+++ b/tests/phpunit/tests/media/test-wpml-beaver-builder-update-media-factory.php
@@ -22,6 +22,7 @@ class Test_WPML_Beaver_Builder_Update_Media_Factory extends OTGS_TestCase {
 	 * @test
 	 */
 	public function it_should_return_an_instance_of_page_builders_media_update() {
+		$this->getMockBuilder( 'WPML_Media_Usage_Factory' )->getMock();
 		$subject = new WPML_Beaver_Builder_Update_Media_Factory();
 		$this->assertInstanceOf( 'WPML_Page_Builders_Update_Media', $subject->create() );
 	}

--- a/tests/phpunit/tests/test-wpml-beaver-builder-cleanup-hooks-factory.php
+++ b/tests/phpunit/tests/test-wpml-beaver-builder-cleanup-hooks-factory.php
@@ -1,0 +1,21 @@
+<?php
+
+class Test_WPML_Beaver_Builder_Cleanup_Hooks_Factory extends OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function it_should_load_on_backend_and_frontend() {
+		$subject = new WPML_Beaver_Builder_Cleanup_Hooks_Factory();
+		$this->assertInstanceOf( 'IWPML_Backend_Action_Loader', $subject );
+		$this->assertInstanceOf( 'IWPML_Frontend_Action_Loader', $subject );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_create_and_return_an_instance() {
+		$subject = new WPML_Beaver_Builder_Cleanup_Hooks_Factory();
+		$this->assertInstanceOf( 'WPML_Beaver_Builder_Cleanup_Hooks', $subject->create() );
+	}
+}

--- a/tests/phpunit/tests/test-wpml-beaver-builder-cleanup-hooks.php
+++ b/tests/phpunit/tests/test-wpml-beaver-builder-cleanup-hooks.php
@@ -1,0 +1,154 @@
+<?php
+
+/**
+ * @group wpmlcore-6211
+ */
+class Test_WPML_Beaver_Builder_Cleanup_Hooks extends OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function it_should_add_hooks() {
+		$subject = new WPML_Beaver_Builder_Cleanup_Hooks();
+		\WP_Mock::expectActionAdded( 'wpml_delete_unused_package_strings', array( $subject, 'delete_block_layout_string' ) );
+		$subject->add_hooks();
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_NOT_delete_strings_if_NO_gutenberg_package() {
+		$package_data = array(
+			'kind'    => 'Beaver Builder',
+			'name'    => 123,
+			'post_id' => 234,
+		);
+
+		$package       = $this->get_package();
+		$package->kind = $package_data['kind'];
+
+		\WP_Mock::onFilter( 'wpml_st_get_post_string_packages' )
+			->with( array(), $package_data['post_id'] )
+			->reply( array( $package ) );
+
+		\WP_Mock::userFunction( 'do_action', array( 'times' => 0 ) );
+
+		$subject = new WPML_Beaver_Builder_Cleanup_Hooks();
+
+		$subject->delete_block_layout_string( $package_data );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_NOT_delete_strings_if_NOT_a_layout() {
+		$package_data = array(
+			'kind'    => WPML_Gutenberg_Integration::PACKAGE_ID,
+			'name'    => 123,
+			'post_id' => 234,
+		);
+
+		$string = (object) array(
+			'title' => 'paragraph',
+			'id'    => 1111,
+		);
+
+		$package       = $this->get_package();
+		$package->kind = $package_data['kind'];
+		$package->name = $package_data['name'];
+		$package->method( 'get_package_strings' )->willReturn( array( $string ) );
+
+		\WP_Mock::onFilter( 'wpml_st_get_post_string_packages' )
+		        ->with( array(), $package_data['post_id'] )
+		        ->reply( array( $package ) );
+
+		\WP_Mock::userFunction( 'do_action', array( 'times' => 0 ) );
+
+		$subject = new WPML_Beaver_Builder_Cleanup_Hooks();
+
+		$subject->delete_block_layout_string( $package_data );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_delete_package_if_unique_string() {
+		$package_data = array(
+			'kind'    => WPML_Gutenberg_Integration::PACKAGE_ID,
+			'name'    => 123,
+			'post_id' => 234,
+		);
+
+		$string = (object) array(
+			'title' => 'fl-builder/layout',
+			'id'    => 1111,
+		);
+
+		$package       = $this->get_package();
+		$package->kind = $package_data['kind'];
+		$package->name = $package_data['name'];
+		$package->method( 'get_package_strings' )->willReturn( array( $string ) );
+
+		\WP_Mock::onFilter( 'wpml_st_get_post_string_packages' )
+			->with( array(), $package_data['post_id'] )
+			->reply( array( $package ) );
+
+		\WP_Mock::expectAction( 'wpml_delete_package', $package_data['name'], $package_data['kind'] );
+
+		$subject = new WPML_Beaver_Builder_Cleanup_Hooks();
+
+		$subject->delete_block_layout_string( $package_data );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_delete_one_string_only() {
+		$package_data = array(
+			'kind'    => WPML_Gutenberg_Integration::PACKAGE_ID,
+			'name'    => 123,
+			'post_id' => 234,
+		);
+
+		$string_layout = (object) array(
+			'title' => 'fl-builder/layout',
+			'id'    => 1111,
+		);
+
+		$string_other = (object) array(
+			'title' => 'paragraph',
+			'id'    => 1112,
+		);
+
+		$package       = $this->get_package();
+		$package->kind = $package_data['kind'];
+		$package->name = $package_data['name'];
+		$package->method( 'get_package_strings' )->willReturn( array( $string_layout, $string_other ) );
+
+		\WP_Mock::onFilter( 'wpml_st_get_post_string_packages' )
+			->with( array(), $package_data['post_id'] )
+			->reply( array( $package ) );
+
+		\WP_Mock::expectAction( 'wpml_st_delete_all_string_data', $string_layout->id );
+
+		$subject = new WPML_Beaver_Builder_Cleanup_Hooks();
+
+		$subject->delete_block_layout_string( $package_data );
+	}
+
+	private function get_package() {
+		return $this->getMockBuilder( 'WPML_Package' )
+			->setMethods( array( 'get_package_strings' ) )
+			->getMock();
+	}
+}
+
+if ( ! class_exists( 'IWPML_Action' ) ) {
+	interface IWPML_Action {}
+}
+
+if ( ! class_exists( 'WPML_Gutenberg_Integration' ) ) {
+	interface WPML_Gutenberg_Integration {
+		const PACKAGE_ID = 'Gutenberg';
+	}
+}

--- a/tests/phpunit/tests/test-wpml-beaver-builder-integration-factory.php
+++ b/tests/phpunit/tests/test-wpml-beaver-builder-integration-factory.php
@@ -24,6 +24,7 @@ class Test_WPML_Beaver_Builder_Integration_Factory extends OTGS_TestCase {
 			array(
 				'WPML_PB_Beaver_Builder_Handle_Custom_Fields_Factory',
 				'WPML_Beaver_Builder_Media_Hooks_Factory',
+				'WPML_Beaver_Builder_Cleanup_Hooks_Factory',
 			)
 		);
 


### PR DESCRIPTION
Beaver Builder uses a special block `wp:fl-builder/layout` to wrap the PB
content, and we should not register this string.

However, it's possible to create a standard post with the block editor,
even when Beaver Builder is active. That's we will only unregister this
block.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6211