### PR TITLE
Sort modules before to register the strings

### DIFF
--- a/src/class-wpml-beaver-builder-register-strings.php
+++ b/src/class-wpml-beaver-builder-register-strings.php
@@ -12,6 +12,7 @@ class WPML_Beaver_Builder_Register_Strings extends WPML_Page_Builders_Register_S
 	protected function register_strings_for_modules( array $data_array, array $package ) {
 		foreach ( $data_array as $data ) {
 			if ( is_array( $data ) ) {
+				$data = $this->sort_modules_before_string_registration( $data );
 				$this->register_strings_for_modules( $data, $package );
 			} elseif ( is_object( $data ) ) {
 				if ( isset( $data->type ) && 'module' === $data->type ) {
@@ -19,5 +20,68 @@ class WPML_Beaver_Builder_Register_Strings extends WPML_Page_Builders_Register_S
 				}
 			}
 		}
+	}
+
+	/**
+	 * The modules are not in the order they appear on the page,
+	 * so we need to sort it before to register the strings.
+	 *
+	 * @param array $modules
+	 *
+	 * @return array
+	 */
+	private function sort_modules_before_string_registration( array $modules ) {
+		uasort( $modules, array( $this, 'sort_modules_by_position_only' ) );
+		return $this->sort_modules_by_parent_and_child( $modules );
+	}
+
+	/**
+	 * We receive all modules as a flat tree and we need to reorder from:
+	 * - child A
+	 * - child A
+	 * - parent A
+	 * - child B
+	 * - parent B
+	 * - child B
+	 * - child C
+	 *
+	 * To:
+	 * - parent A
+	 * - child A
+	 * - child B
+	 * - parent B
+	 * - child A
+	 * - child B
+	 * - child C
+	 *
+	 * The relative positions are already sorted by `sort_modules_by_position_only`
+	 *
+	 * @param array        $all_modules
+	 * @param string|null  $parent_hash
+	 * @param array        $sorted_modules
+	 *
+	 * @return array
+	 */
+	private function sort_modules_by_parent_and_child( array $all_modules, $parent_hash = null, array $sorted_modules = array() ){
+		foreach ( $all_modules as $hash => $module ) {
+
+			if ( $module->parent === $parent_hash ) {
+				$sorted_modules[ $hash ] = $module;
+				unset( $all_modules[ $hash ] );
+				$sorted_modules = $this->sort_modules_by_parent_and_child( $all_modules, $module->node, $sorted_modules );
+			}
+		}
+
+		return $sorted_modules;
+	}
+
+	/**
+	 * @param stdClass $a
+	 * @param stdClass $b
+	 *
+	 * @return int
+	 */
+	private function sort_modules_by_position_only( stdClass $a, stdClass $b ) {
+		return ( (int) $a->position < (int) $b->position ) ? -1 : 1;
 	}
 }

--- a/tests/phpunit/tests/test-wpml-beaver-builder-register-strings.php
+++ b/tests/phpunit/tests/test-wpml-beaver-builder-register-strings.php
@@ -16,7 +16,12 @@ class Test_WPML_Beaver_Builder_Register_Stings extends WPML_PB_TestCase2 {
 
 		$beaver_builder_field_data = array(
 			array(
-				(object) array( 'type' => 'module', 'settings' => $settings, 'node' => $node_id ),
+				(object) array(
+					'type'     => 'module',
+					'settings' => $settings,
+					'node'     => $node_id,
+					'parent'   => null,
+				),
 			)
 		);
 
@@ -49,6 +54,60 @@ class Test_WPML_Beaver_Builder_Register_Stings extends WPML_PB_TestCase2 {
 			                         $string->get_name()
 		                         );
 
+		$data_settings = $this->get_data_settings( $beaver_builder_field_data );
+
+		$subject = new WPML_Beaver_Builder_Register_Strings( $translatable_nodes, $data_settings, $string_registration_mock );
+		$subject->register_strings( $post, $package );
+	}
+
+	/**
+	 * @test
+	 * @group wpmlcore-6331
+	 */
+	public function it_should_sort_modules_before_register_strings() {
+		list( $name, $post, $package ) = $this->get_post_and_package( 'Beaver builder' );
+
+		$beaver_builder_field_data = $this->get_meta_data_for_sort_modules();
+
+		\WP_Mock::wpFunction( 'get_post_meta', array(
+			'times'  => 1,
+			'args'   => array( $post->ID, '_fl_builder_data', false ),
+			'return' => $beaver_builder_field_data,
+		));
+
+		$get_strings_map = array(
+			array( 'module-1', $this->get_module_settings( 1 ), array( new WPML_PB_String( 'Text #1', 'name-1', 'title 1', 'LINE' ) ) ),
+			array( 'module-2', $this->get_module_settings( 2 ), array( new WPML_PB_String( 'Text #2', 'name-2', 'title 2', 'LINE' ) ) ),
+			array( 'module-3', $this->get_module_settings( 3 ), array( new WPML_PB_String( 'Text #3', 'name-3', 'title 3', 'LINE' ) ) ),
+			array( 'module-4', $this->get_module_settings( 4 ), array( new WPML_PB_String( 'Text #4', 'name-4', 'title 4', 'LINE' ) ) ),
+			array( 'module-5', $this->get_module_settings( 5 ), array( new WPML_PB_String( 'Text #5', 'name-5', 'title 5', 'LINE' ) ) ),
+		);
+
+		$translatable_nodes = $this->getMockBuilder( 'WPML_Beaver_Builder_Translatable_Nodes' )
+			->setMethods( array( 'get' ) )
+			->disableOriginalConstructor()->getMock();
+		$translatable_nodes->method( 'get' )->willReturnMap( $get_strings_map );
+
+		$string_registration_mock = $this->getMockBuilder( 'WPML_PB_String_Registration' )
+			->setMethods( array( 'register_string' ) )
+			->disableOriginalConstructor()->getMock();
+		$string_registration_mock->expects( $this->exactly( 5 ) )
+		                         ->method( 'register_string' )
+		                         ->withConsecutive(
+			                         array( $post->ID, 'Text #1', 'LINE', 'title 1', 'name-1' ),
+			                         array( $post->ID, 'Text #2', 'LINE', 'title 2', 'name-2' ),
+			                         array( $post->ID, 'Text #3', 'LINE', 'title 3', 'name-3' ),
+			                         array( $post->ID, 'Text #4', 'LINE', 'title 4', 'name-4' ),
+			                         array( $post->ID, 'Text #5', 'LINE', 'title 5', 'name-5' )
+		                         );
+
+		$data_settings = $this->get_data_settings( $beaver_builder_field_data );
+
+		$subject = new WPML_Beaver_Builder_Register_Strings( $translatable_nodes, $data_settings, $string_registration_mock );
+		$subject->register_strings( $post, $package );
+	}
+
+	private function get_data_settings( array $beaver_builder_field_data ) {
 		$data_settings = $this->getMockBuilder( 'WPML_Beaver_Builder_Data_Settings' )
 		                      ->disableOriginalConstructor()
 		                      ->getMock();
@@ -63,8 +122,154 @@ class Test_WPML_Beaver_Builder_Register_Stings extends WPML_PB_TestCase2 {
 		              ->with( $beaver_builder_field_data )
 		              ->willReturn( $beaver_builder_field_data );
 
-		$subject = new WPML_Beaver_Builder_Register_Strings( $translatable_nodes, $data_settings, $string_registration_mock );
-		$subject->register_strings( $post, $package );
+		return $data_settings;
 	}
 
+	private function get_meta_data_for_sort_modules() {
+		return array(
+			array(
+				'row-a'          => (object) array(
+					'node'     => 'row-a',
+					'type'     => 'row',
+					'parent'   => null,
+					'position' => 1,
+					'settings' => '',
+				),
+				'column-group-a' => (object) array(
+					'node'     => 'column-group-a',
+					'type'     => 'column-group',
+					'parent'   => 'row-a',
+					'position' => 2,
+					'settings' => '',
+				),
+				'column-a'       => (object) array(
+					'node'     => 'column-a',
+					'type'     => 'column',
+					'parent'   => 'column-group-a',
+					'position' => 0,
+					'settings' => (object) array(),
+				),
+				'module-4'       => (object) array(
+					'node'     => 'module-4',
+					'type'     => 'module',
+					'parent'   => 'column-a',
+					'position' => 1,
+					'settings' => $this->get_module_settings( 4 ),
+				),
+				'module-5'       => (object) array(
+					'node'     => 'module-5',
+					'type'     => 'module',
+					'parent'   => 'column-a',
+					'position' => 2,
+					'settings' => $this->get_module_settings( 5 ),
+				),
+				'module-3'       => (object) array(
+					'node'     => 'module-3',
+					'type'     => 'module',
+					'parent'   => 'column-a',
+					'position' => 0,
+					'settings' => $this->get_module_settings( 3 ),
+				),
+				'column-b'       => (object) array(
+					'node'     => 'column-b',
+					'type'     => 'column',
+					'parent'   => 'column-group-b',
+					'position' => 0,
+					'settings' => '',
+				),
+				'column-group-b' => (object) array(
+					'node'     => 'column-group-b',
+					'type'     => 'column-group',
+					'parent'   => 'row-a',
+					'position' => 0,
+					'settings' => '',
+				),
+				'module-1'       => (object) array(
+					'node'     => 'module-1',
+					'type'     => 'module',
+					'parent'   => 'column-b',
+					'position' => 0,
+					'settings' => $this->get_module_settings( 1 ),
+				),
+				'row-b'          => (object) array(
+					'node'     => 'row-b',
+					'type'     => 'row',
+					'parent'   => null,
+					'position' => 0,
+					'settings' => '',
+				),
+				'column-group-c' => (object) array(
+					'node'     => 'column-group-c',
+					'type'     => 'column-group',
+					'parent'   => 'row-b',
+					'position' => 1,
+					'settings' => '',
+				),
+				'column-c'       => (object) array(
+					'node'     => 'column-c',
+					'type'     => 'column',
+					'parent'   => 'column-group-c',
+					'position' => 0,
+					'settings' => '',
+				),
+				'column-group-d' => (object) array(
+					'node'     => 'column-group-d',
+					'type'     => 'column-group',
+					'parent'   => 'row-b',
+					'position' => 0,
+					'settings' => '',
+				),
+				'column-d'       => (object) array(
+					'node'     => 'column-d',
+					'type'     => 'column',
+					'parent'   => 'column-group-d',
+					'position' => 0,
+					'settings' => '',
+				),
+				'module-2'       => (object) array(
+					'node'     => 'module-2',
+					'type'     => 'module',
+					'parent'   => 'column-e',
+					'position' => 0,
+					'settings' => $this->get_module_settings( 2 ),
+				),
+				'column-group-e' => (object) array(
+					'node'     => 'column-group-e',
+					'type'     => 'column-group',
+					'parent'   => 'row-a',
+					'position' => 1,
+					'settings' => '',
+				),
+				'column-e'       => (object) array(
+					'node'     => 'column-e',
+					'type'     => 'column',
+					'parent'   => 'column-group-e',
+					'position' => 0,
+					'settings' => '',
+				),
+			),
+		);
+	}
+
+	/**
+	 * @param int $location
+	 *
+	 * @return stdClass
+	 */
+	private function get_module_settings( $location ) {
+		/**
+		 * We need to provide the same objects so it's accepted by
+		 * argument matcher handler of `WPML_Beaver_Builder_Translatable_Nodes::get`'s mock
+		 */
+		static $settings = array();
+
+		if ( ! isset( $settings[ $location ] ) ) {
+			$settings[ $location ] = (object) array(
+				'text' => 'Text #' . $location,
+				'type' => 'rich-text',
+			);
+		}
+
+		return $settings[ $location ];
+	}
 }


### PR DESCRIPTION
I struggled a little to find the smartest logic to sort the modules, and also to implement the tests, but it looks fine now.

The data used for the test was taken from my test page (just removed the unnecessary stuff) => see https://github.com/OnTheGoSystems/wpml-page-builders-beaver-builder/compare/wpmlcore-6331?expand=1#diff-77dbb17f691cc1dc504c62173c5c2345R128.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6331