### PR TITLE
Escape meta data with slash before to call update_post_meta

### DIFF
--- a/src/class-wpml-beaver-builder-data-settings.php
+++ b/src/class-wpml-beaver-builder-data-settings.php
@@ -38,7 +38,7 @@ class WPML_Beaver_Builder_Data_Settings implements IWPML_Page_Builders_Data_Sett
 	 * @return array
 	 */
 	public function prepare_data_for_saving( array $data ) {
-		return $data;
+		return $this->slash( $data );
 	}
 
 	/**
@@ -56,4 +56,31 @@ class WPML_Beaver_Builder_Data_Settings implements IWPML_Page_Builders_Data_Sett
 	}
 
 	public function add_hooks(){}
+
+	/**
+	 * Adds slashes to data going into the database as WordPress
+	 * removes them when we save using update_metadata. This is done
+	 * to ensure slashes in user input aren't removed.
+	 *
+	 * Inspired by `\FLBuilderModel::slash_settings`
+	 *
+	 * @param mixed $data The data to slash.
+	 *
+	 * @return mixed The slashed data.
+	 */
+	private function slash( $data ) {
+		if ( is_array( $data ) ) {
+			foreach ( $data as $key => $val ) {
+				$data[ $key ] = $this->slash( $val );
+			}
+		} elseif ( is_object( $data ) ) {
+			foreach ( $data as $key => $val ) {
+				$data->$key = $this->slash( $val );
+			}
+		} elseif ( is_string( $data ) ) {
+			$data = wp_slash( $data );
+		}
+
+		return $data;
+	}
 }

--- a/tests/phpunit/tests/test-wpml-beaver-builder-data-settings.php
+++ b/tests/phpunit/tests/test-wpml-beaver-builder-data-settings.php
@@ -49,17 +49,38 @@ class Test_WPML_Beaver_Builder_Data_Settings extends OTGS_TestCase {
 
 	/**
 	 * @test
+	 * @group wpmlcore-6774
 	 */
 	public function it_prepares_data_for_saving() {
-		$data = array(
-			'id' => mt_rand(),
-			'something' => rand_str( 10 ),
-		);
+		$data = [
+			'gt5s65g365' => (object) [
+				'node'     => 'gt5s65g365',
+				'settings' => (object) [
+					'text' => 'My text in object',
+					'data' => [
+						'text1' => 'My text in array',
+					]
+				]
+			]
+		];
 
-		\WP_Mock::wpFunction( 'wp_json_encode', array(
-			'args'   => array( $data ),
-			'return' => json_encode( $data ),
-		) );
+		\WP_Mock::userFunction( 'wp_slash', [
+			'times'      => 1,
+			'args'       => [ 'gt5s65g365' ],
+			'return_arg' => true,
+		] );
+
+		\WP_Mock::userFunction( 'wp_slash', [
+			'times'      => '1+',
+			'args'       => [ 'My text in object' ],
+			'return_arg' => true,
+		] );
+
+		\WP_Mock::userFunction( 'wp_slash', [
+			'times'      => 1,
+			'args'       => [ 'My text in array' ],
+			'return_arg' => true,
+		] );
 
 		$subject = new WPML_Beaver_Builder_Data_Settings();
 		$this->assertEquals( $data, $subject->prepare_data_for_saving( $data ) );


### PR DESCRIPTION
The escaping logic has been inspired by
`\FLBuilderModel::slash_settings`.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6774