### PR TITLE
Fix so meta data isn't overriden when WPML media is active and a Beav…

### DIFF
--- a/src/class-wpml-beaver-builder-data-settings-for-media.php
+++ b/src/class-wpml-beaver-builder-data-settings-for-media.php
@@ -1,0 +1,11 @@
+<?php
+
+class WPML_Beaver_Builder_Data_Settings_For_Media extends WPML_Beaver_Builder_Data_Settings {
+
+	/**
+	 * @return array
+	 */
+	public function get_fields_to_copy() {
+		return [];
+	}
+}

--- a/src/media/class-wpml-beaver-builder-update-media-factory.php
+++ b/src/media/class-wpml-beaver-builder-update-media-factory.php
@@ -2,33 +2,22 @@
 
 class WPML_Beaver_Builder_Update_Media_Factory implements IWPML_PB_Media_Update_Factory {
 
-	/** @var  */
-	private $media_translate;
 
 	public function create() {
 		global $sitepress;
 
+		$media_translate = new WPML_Page_Builders_Media_Translate(
+			new WPML_Translation_Element_Factory( $sitepress ),
+			new WPML_Media_Image_Translate( $sitepress, new WPML_Media_Attachment_By_URL_Factory() )
+		);
+
 		return new WPML_Page_Builders_Update_Media(
-			new WPML_Page_Builders_Update( new WPML_Beaver_Builder_Data_Settings() ),
+			new WPML_Page_Builders_Update( new WPML_Beaver_Builder_Data_Settings_For_Media() ),
 			new WPML_Translation_Element_Factory( $sitepress ),
 			new WPML_Beaver_Builder_Media_Nodes_Iterator(
-				new WPML_Beaver_Builder_Media_Node_Provider( $this->get_media_translate() )
+				new WPML_Beaver_Builder_Media_Node_Provider( $media_translate )
 			),
-			new WPML_Page_Builders_Media_Usage( $this->get_media_translate(), new WPML_Media_Usage_Factory() )
+			new WPML_Page_Builders_Media_Usage( $media_translate, new WPML_Media_Usage_Factory() )
 		);
-	}
-
-	/** @return WPML_Page_Builders_Media_Translate */
-	private function get_media_translate() {
-		global $sitepress;
-
-		if ( ! $this->media_translate ) {
-			$this->media_translate = new WPML_Page_Builders_Media_Translate(
-				new WPML_Translation_Element_Factory( $sitepress ),
-				new WPML_Media_Image_Translate( $sitepress, new WPML_Media_Attachment_By_URL_Factory() )
-			);
-		}
-
-		return $this->media_translate;
 	}
 }

--- a/tests/phpunit/tests/test-wpml-beaver-builder-data-settings-for-media.php
+++ b/tests/phpunit/tests/test-wpml-beaver-builder-data-settings-for-media.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * Class Test_WPML_Beaver_Builder_Data_Settings_For_Media
+ *
+ * @group page-builders
+ * @group beaver-builder
+ */
+class Test_WPML_Beaver_Builder_Data_Settings_For_Media extends OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function fields_to_copy_should_be_empty() {
+		$subject = new WPML_Beaver_Builder_Data_Settings_For_Media();
+		$this->assertEquals( [], $subject->get_fields_to_copy() );
+	}
+
+}


### PR DESCRIPTION
Fix so meta data isn't overriden when WPML media is active and a Beaver Builder post is publishied - https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6759