### PR TITLE
Do not register strings from embedded global modules

### DIFF
--- a/src/class-wpml-beaver-builder-register-strings.php
+++ b/src/class-wpml-beaver-builder-register-strings.php
@@ -15,7 +15,7 @@ class WPML_Beaver_Builder_Register_Strings extends WPML_Page_Builders_Register_S
 				$data = $this->sort_modules_before_string_registration( $data );
 				$this->register_strings_for_modules( $data, $package );
 			} elseif ( is_object( $data ) ) {
-				if ( isset( $data->type ) && 'module' === $data->type ) {
+				if ( isset( $data->type ) && 'module' === $data->type && ! $this->is_embedded_global_module( $data ) ) {
 					$this->register_strings_for_node( $data->node, $data->settings, $package );
 				}
 			}
@@ -83,5 +83,14 @@ class WPML_Beaver_Builder_Register_Strings extends WPML_Page_Builders_Register_S
 	 */
 	private function sort_modules_by_position_only( stdClass $a, stdClass $b ) {
 		return ( (int) $a->position < (int) $b->position ) ? -1 : 1;
+	}
+
+	/**
+	 * @param object $data
+	 *
+	 * @return bool
+	 */
+	private function is_embedded_global_module( $data ) {
+		return ! empty( $data->template_node_id ) && $data->template_node_id !== $data->node;
 	}
 }

--- a/tests/phpunit/tests/test-wpml-beaver-builder-register-strings.php
+++ b/tests/phpunit/tests/test-wpml-beaver-builder-register-strings.php
@@ -65,6 +65,105 @@ class Test_WPML_Beaver_Builder_Register_Stings extends WPML_PB_TestCase2 {
 
 	/**
 	 * @test
+	 * @group wpmlcore-6435
+	 */
+	public function it_should_not_register_strings_from_embedded_global_modules() {
+		list( , $post, $package ) = $this->get_post_and_package( 'Beaver builder' );
+
+		$node_id          = 'some_node_id';
+		$template_node_id = 'some_external_module_id';
+		$settings         = [ rand_str() => rand_str() ];
+		$string           = new WPML_PB_String( rand_str(), rand_str(), rand_str(), rand_str() );
+
+		$beaver_builder_field_data = [
+			[
+				(object) [
+					'type'             => 'module',
+					'settings'         => $settings,
+					'node'             => $node_id,
+					'parent'           => null,
+					'template_node_id' => $template_node_id,
+				],
+			]
+		];
+
+		\WP_Mock::wpFunction( 'get_post_meta', array(
+			'times'  => 1,
+			'args'   => [ $post->ID, '_fl_builder_data', false ],
+			'return' => $beaver_builder_field_data,
+		) );
+
+		$translatable_nodes = $this->getMockBuilder( WPML_Beaver_Builder_Translatable_Nodes::class )
+			->setMethods( [ 'get' ] )
+			->disableOriginalConstructor()->getMock();
+
+		$string_registration_mock = \Mockery::mock( 'WPML_PB_String_Registration' );
+		$string_registration_mock->shouldReceive( 'register_string' )->never();
+
+		$data_settings = $this->get_data_settings( $beaver_builder_field_data );
+
+		$subject = new WPML_Beaver_Builder_Register_Strings( $translatable_nodes, $data_settings, $string_registration_mock );
+		$subject->register_strings( $post, $package );
+	}
+
+	/**
+	 * @test
+	 * @group wpmlcore-6435
+	 */
+	public function it_should_register_strings_from_global_modules() {
+		list( , $post, $package ) = $this->get_post_and_package( 'Beaver builder' );
+
+		$node_id  = 'some_node_id';
+		$settings = [ rand_str() => rand_str() ];
+		$string   = new WPML_PB_String( rand_str(), rand_str(), rand_str(), rand_str() );
+
+		$beaver_builder_field_data = [
+			[
+				(object) [
+					'type'             => 'module',
+					'settings'         => $settings,
+					'node'             => $node_id,
+					'parent'           => null,
+					'template_node_id' => $node_id,
+				],
+			]
+		];
+
+		\WP_Mock::wpFunction( 'get_post_meta', array(
+			'times'  => 1,
+			'args'   => [ $post->ID, '_fl_builder_data', false ],
+			'return' => $beaver_builder_field_data,
+		) );
+
+		$translatable_nodes = $this->getMockBuilder( WPML_Beaver_Builder_Translatable_Nodes::class )
+			->setMethods( [ 'get' ] )
+			->disableOriginalConstructor()->getMock();
+		$translatable_nodes->expects( $this->once() )
+			->method( 'get' )
+			->with( $node_id, $settings )
+			->willReturn( [ $string ] );
+
+		$string_registration_mock = \Mockery::mock( 'WPML_PB_String_Registration' );
+		$string_registration_mock->shouldReceive( 'register_string' )
+			->once()
+			->with(
+				$post->ID,
+				$string->get_value(),
+				$string->get_editor_type(),
+				$string->get_title(),
+				$string->get_name(),
+				1,
+				$string->get_wrap_tag()
+			);
+
+		$data_settings = $this->get_data_settings( $beaver_builder_field_data );
+
+		$subject = new WPML_Beaver_Builder_Register_Strings( $translatable_nodes, $data_settings, $string_registration_mock );
+		$subject->register_strings( $post, $package );
+	}
+
+	/**
+	 * @test
 	 * @group wpmlcore-6331
 	 */
 	public function it_should_sort_modules_before_register_strings() {


### PR DESCRIPTION
This will prevent including strings from the global module in the translation job of
the page embedding the global module.

Until now, we had these strings in the translation job of the page, but
it was not applied, just confusing the user.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6435