### PR TITLE
Register module strings that was saved while editing a page on the frontend BB editor

### DIFF
--- a/src/class-wpml-beaver-builder-register-strings.php
+++ b/src/class-wpml-beaver-builder-register-strings.php
@@ -31,8 +31,12 @@ class WPML_Beaver_Builder_Register_Strings extends WPML_Page_Builders_Register_S
 	 * @return array
 	 */
 	private function sort_modules_before_string_registration( array $modules ) {
-		uasort( $modules, array( $this, 'sort_modules_by_position_only' ) );
-		return $this->sort_modules_by_parent_and_child( $modules );
+		if ( count( $modules ) > 1 ) {
+			uasort( $modules, array( $this, 'sort_modules_by_position_only' ) );
+			return $this->sort_modules_by_parent_and_child( $modules );
+		}
+
+		return $modules;
 	}
 
 	/**


### PR DESCRIPTION
The shape of the data is not the same when a module is saved
independently or from within an edited page. In the former case, the
unique node has a parent node id but it does not match to anything
inside the saved module.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-7138