### PR TITLE
Filter `wpml_pb_is_editing_translation_with_native_editor`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,8 @@
     "otgs/unit-tests-framework": "~1.2.0",
     "wpml/page-builders": "dev-develop",
     "wpml/collect": "dev-wpml-collect-rename",
-    "wpml/fp": "^0.1.2"
+    "wpml/fp": "^0.1.2",
+    "wpml/wp": "dev-develop",
+    "composer/composer": "^1.10"
   }
 }

--- a/src/Hooks/Editor.php
+++ b/src/Hooks/Editor.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace WPML\PB\BeaverBuilder\Hooks;
+
+use WPML\FP\Obj;
+use WPML\LIB\WP\Hooks;
+use function WPML\FP\spreadArgs;
+
+class Editor implements \IWPML_Frontend_Action {
+
+	public function add_hooks() {
+		Hooks::onFilter( 'wpml_pb_is_editing_translation_with_native_editor' )
+			->then( spreadArgs( function( $isTranslationWithNativeEditor ) {
+				return $isTranslationWithNativeEditor
+					|| Obj::path( [ 'fl_builder_data', 'action' ], $_POST ) === 'save_layout';
+
+			} ) );
+	}
+}

--- a/src/class-wpml-beaver-builder-integration-factory.php
+++ b/src/class-wpml-beaver-builder-integration-factory.php
@@ -12,6 +12,7 @@ class WPML_Beaver_Builder_Integration_Factory {
 				'WPML_Beaver_Builder_Media_Hooks_Factory',
 				\WPML\PB\BeaverBuilder\TranslationJob\Hooks::class,
 				\WPML\PB\BeaverBuilder\Config\Factory::class,
+				\WPML\PB\BeaverBuilder\Hooks\Editor::class,
 			)
 		);
 

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -39,3 +39,33 @@ if ( ! defined( 'ABSPATH' ) ) {
 require_once __DIR__ . '/stubs/wpml-interfaces.php';
 require_once __DIR__ . '/../../vendor/autoload.php';
 require_once __DIR__ . '/../../vendor/otgs/unit-tests-framework/phpunit/bootstrap.php';
+
+try {
+	if ( ! spl_autoload_register( 'autoload_tests_classes' ) ) {
+		echo 'Test classes cannot be loaded!';
+		exit( 1 );
+	}
+} catch ( Exception $e ) {
+	echo $e->getMessage();
+	exit( 1 );
+}
+
+function autoload_tests_classes( $class ) {
+	static $maps;
+
+	if ( ! $maps ) {
+		$dirs = [
+			__DIR__ . '/../../vendor/wpml/wp/tests/mocks',
+		];
+
+		$maps = [];
+		foreach ( $dirs as $dir ) {
+			$maps = array_merge( $maps, \Composer\Autoload\ClassMapGenerator::createMap( $dir ) );
+		}
+	}
+
+	if ( $maps && array_key_exists( $class, $maps ) ) {
+		/** @noinspection PhpIncludeInspection */
+		require_once $maps[ $class ];
+	}
+}

--- a/tests/phpunit/tests/Hooks/TestEditor.php
+++ b/tests/phpunit/tests/Hooks/TestEditor.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace WPML\PB\BeaverBuilder\Hooks;
+
+use WPML\LIB\WP\OnActionMock;
+
+/**
+ * @group hooks
+ * @group editor
+ */
+class TestEditor extends \OTGS_TestCase {
+
+	use OnActionMock;
+
+	public function setUp() {
+		parent::setUp();
+		$this->setUpOnAction();
+	}
+
+	public function tearDown() {
+		unset( $_POST['fl_builder_data'] );
+		$this->tearDownOnAction();
+		parent::tearDown();
+	}
+
+	/**
+	 * @test
+	 */
+	public function itReturnsTrueIfAlreadyTranslatingWithNativeEditor() {
+		$subject = new Editor();
+		$subject->add_hooks();
+
+		$this->assertTrue( $this->runFilter( 'wpml_pb_is_editing_translation_with_native_editor', true ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function itReturnsTrueIfTranslatingWithBeaverBuilderNativeEditor() {
+		$_POST = [
+			'fl_builder_data' => [
+				'action' => 'save_layout',
+			],
+		];
+
+		$subject = new Editor();
+		$subject->add_hooks();
+
+		$this->assertTrue( $this->runFilter( 'wpml_pb_is_editing_translation_with_native_editor', false ) );
+	}
+}

--- a/tests/phpunit/tests/test-wpml-beaver-builder-integration-factory.php
+++ b/tests/phpunit/tests/test-wpml-beaver-builder-integration-factory.php
@@ -26,6 +26,7 @@ class Test_WPML_Beaver_Builder_Integration_Factory extends OTGS_TestCase {
 				'WPML_Beaver_Builder_Media_Hooks_Factory',
 				\WPML\PB\BeaverBuilder\TranslationJob\Hooks::class,
 				\WPML\PB\BeaverBuilder\Config\Factory::class,
+				\WPML\PB\BeaverBuilder\Hooks\Editor::class,
 			)
 		);
 


### PR DESCRIPTION
Same issue as https://github.com/OnTheGoSystems/wpml-page-builders-elementor/pull/149.

This will ensure we set the right `_last_translation_edit_mode` post
meta when a translation is edited with Beaver Builder's editor.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-7656