### PR TITLE
Improve the way we flag is a translation has been edited with Beaver Builder or not

### DIFF
--- a/src/Hooks/Editor.php
+++ b/src/Hooks/Editor.php
@@ -9,10 +9,13 @@ use function WPML\FP\spreadArgs;
 class Editor implements \IWPML_Frontend_Action {
 
 	public function add_hooks() {
-		Hooks::onFilter( 'wpml_pb_is_editing_translation_with_native_editor' )
-			->then( spreadArgs( function( $isTranslationWithNativeEditor ) {
+		Hooks::onFilter( 'wpml_pb_is_editing_translation_with_native_editor', 10, 2 )
+			->then( spreadArgs( function( $isTranslationWithNativeEditor, $translatedPostId ) {
 				return $isTranslationWithNativeEditor
-					|| Obj::path( [ 'fl_builder_data', 'action' ], $_POST ) === 'save_layout';
+					|| (
+							Obj::path( [ 'fl_builder_data', 'action' ], $_POST ) === 'save_layout'
+							&& (int) Obj::path( [ 'fl_builder_data', 'post_id' ], $_POST ) === $translatedPostId
+				       );
 
 			} ) );
 	}

--- a/tests/phpunit/tests/Hooks/TestEditor.php
+++ b/tests/phpunit/tests/Hooks/TestEditor.php
@@ -12,13 +12,16 @@ class TestEditor extends \OTGS_TestCase {
 
 	use OnActionMock;
 
+	const ORIGINAL_POST_ID = 123;
+	const TRANSLATION_POST_ID = 456;
+
 	public function setUp() {
 		parent::setUp();
 		$this->setUpOnAction();
 	}
 
 	public function tearDown() {
-		unset( $_POST['fl_builder_data'] );
+		unset( $_POST['fl_builder_data'], $_POST['post_id'] );
 		$this->tearDownOnAction();
 		parent::tearDown();
 	}
@@ -30,7 +33,7 @@ class TestEditor extends \OTGS_TestCase {
 		$subject = new Editor();
 		$subject->add_hooks();
 
-		$this->assertTrue( $this->runFilter( 'wpml_pb_is_editing_translation_with_native_editor', true ) );
+		$this->assertTrue( $this->runFilter( 'wpml_pb_is_editing_translation_with_native_editor', true, self::TRANSLATION_POST_ID ) );
 	}
 
 	/**
@@ -39,13 +42,31 @@ class TestEditor extends \OTGS_TestCase {
 	public function itReturnsTrueIfTranslatingWithBeaverBuilderNativeEditor() {
 		$_POST = [
 			'fl_builder_data' => [
-				'action' => 'save_layout',
+				'action'  => 'save_layout',
+				'post_id' => (string) self::TRANSLATION_POST_ID,
 			],
 		];
 
 		$subject = new Editor();
 		$subject->add_hooks();
 
-		$this->assertTrue( $this->runFilter( 'wpml_pb_is_editing_translation_with_native_editor', false ) );
+		$this->assertTrue( $this->runFilter( 'wpml_pb_is_editing_translation_with_native_editor', false, self::TRANSLATION_POST_ID ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function itReturnsFalseIfEditingOriginalWithBeaverBuilderNativeEditor() {
+		$_POST = [
+			'fl_builder_data' => [
+				'action'  => 'save_layout',
+				'post_id' => (string) self::ORIGINAL_POST_ID,
+			],
+		];
+
+		$subject = new Editor();
+		$subject->add_hooks();
+
+		$this->assertFalse( $this->runFilter( 'wpml_pb_is_editing_translation_with_native_editor', false, self::TRANSLATION_POST_ID ) );
 	}
 }


### PR DESCRIPTION
We need to make sure the globally edited post ID is the same as the translated one.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-8858